### PR TITLE
Fatal errors relating to Interfaces used in Application.php

### DIFF
--- a/Herbert/Framework/Application.php
+++ b/Herbert/Framework/Application.php
@@ -89,6 +89,16 @@ class Application extends \Illuminate\Container\Container implements \Illuminate
     }
 
     /**
+     *  Get the base path
+     *
+     *  @return mixed
+     */
+    public function basePath()
+    {
+        return $plugin->getBasePath();
+    }
+
+    /**
      * Get all loaded plugins.
      *
      * @return array
@@ -568,7 +578,7 @@ class Application extends \Illuminate\Container\Container implements \Illuminate
      * @param  array   $parameters
      * @return mixed
      */
-    public function make($abstract, $parameters = array())
+    public function make($abstract, Array $parameters = array())
     {
         $abstract = $this->getAlias($abstract);
 

--- a/Herbert/Framework/Application.php
+++ b/Herbert/Framework/Application.php
@@ -89,13 +89,13 @@ class Application extends \Illuminate\Container\Container implements \Illuminate
     }
 
     /**
-     *  Get the base path
+     *  Added to satisfy interface
      *
-     *  @return mixed
+     *  @return null
      */
     public function basePath()
     {
-        return $plugin->getBasePath();
+        return;
     }
 
     /**


### PR DESCRIPTION
First was:
Fatal error: Declaration of Herbert\Framework\Application::make() must be compatible with Illuminate\Contracts\Container\Container::make($abstract, array $parameters = Array) 

Fixed by typecasting $parameters to Array as the Interface does.

Second:
Fatal error: Class Herbert\Framework\Application contains 1 abstract method and must therefore be declared abstract or implement the remaining methods (Illuminate\Contracts\Foundation\Application::basePath) 

Fixed by creating basePath() that returns nothing to satisfy the interface. 

I guess this probably wants implementing properly to be compatible with the interface, but I'm not familiar with the rest of the framework and wanted to a quick fix to carry on working. 
