### PR TITLE
added version constraint config

### DIFF
--- a/bootstrap/autoload.php
+++ b/bootstrap/autoload.php
@@ -30,21 +30,28 @@ $iterator = new DirectoryIterator(ABSPATH . 'wp-content/plugins');
 
 foreach ($iterator as $directory)
 {
-    if (!$directory->valid() || $directory->isDot() || !$directory->isDir())
+    if ( ! $directory->valid() || $directory->isDot() || ! $directory->isDir())
     {
         continue;
     }
 
     $root = $directory->getPath() . '/' . $directory->getFilename();
 
-    if (!file_exists($require = $root . '/herbert.config.php'))
+    if ( ! file_exists($root . '/herbert.config.php'))
     {
         continue;
     }
 
-    register_activation_hook($root . '/plugin.php', function () use ($herbert, $root, $require)
+    $config = $herbert->getPluginConfig($root);
+
+    if ( ! $herbert->shouldLoadPlugin($config))
     {
-        $herbert->loadPlugin($root);
+        continue;
+    }
+
+    register_activation_hook($root . '/plugin.php', function () use ($herbert, $config, $root)
+    {
+        $herbert->loadPlugin($config);
         $herbert->activatePlugin($root);
     });
 
@@ -53,12 +60,12 @@ foreach ($iterator as $directory)
         $herbert->deactivatePlugin($root);
     });
 
-    if (!is_plugin_active(substr($root, strlen(ABSPATH . 'wp-content/plugins/')) . '/plugin.php'))
+    if ( ! is_plugin_active(substr($root, strlen(ABSPATH . 'wp-content/plugins/')) . '/plugin.php'))
     {
         continue;
     }
 
-    $herbert->loadPlugin($root);
+    $herbert->loadPlugin($config);
 }
 
 /**

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,8 @@
   "license": "MIT",
   "require": {
     "twig/twig": "1.16.*",
-    "illuminate/database": "5.1.*"
+    "illuminate/database": "5.1.*",
+    "vierbergenlars/php-semver": "~3.0"
   },
   "autoload": {
     "psr-4": {


### PR DESCRIPTION
Allows for a configurable version constraint on the Herbert Framework.

Usable via the 'constraint' key in the `herbert.config.php`, eg:

``` php
<?php

return [

    /**
     * The Herbert version constraint.
     */
    'constraint' => '~1.0'

];
```
