### PR TITLE
moved the notifications to it's own class

### DIFF
--- a/Herbert/Framework/Base/Plugin.php
+++ b/Herbert/Framework/Base/Plugin.php
@@ -24,75 +24,11 @@ class Plugin implements PluginContract {
     protected $container;
 
     /**
-     * @var array
-     */
-    protected $notices = [];
-
-    /**
      * @param $path
      */
     public function __construct($path)
     {
         $this->setBasePath($path);
-
-        add_action('admin_notices', [$this, 'sendNotices']);
-    }
-
-    /**
-     * Adds a notice.
-     *
-     * @param        $message
-     * @param string $class
-     */
-    public function notify($message, $class = 'updated')
-    {
-        $this->notices[] = [
-            'message' => $message,
-            'class'   => $class
-        ];
-    }
-
-    /**
-     * Adds a success notice.
-     *
-     * @param $message
-     */
-    public function notifySuccess($message)
-    {
-        $this->notify($message, 'updated');
-    }
-
-    /**
-     * Adds a warning notice.
-     *
-     * @param $message
-     */
-    public function notifyWarning($message)
-    {
-        $this->notify($message, 'update-nag');
-    }
-
-    /**
-     * Adds an error notice.
-     *
-     * @param $message
-     */
-    public function notifyError($message)
-    {
-        $this->notify($message, 'update-error');
-    }
-
-    /**
-     * Sends all the accumulated notices.
-     *
-     * @return void
-     */
-    public function sendNotices()
-    {
-        foreach ($this->notices as $notice)
-        {
-            echo "<div class=\"{$notice['class']}\"><p>{$notice['message']}</p></div>";
-        }
     }
 
     /**

--- a/Herbert/Framework/Notifier.php
+++ b/Herbert/Framework/Notifier.php
@@ -1,0 +1,104 @@
+<?php namespace Herbert\Framework;
+
+/**
+ * @see http://getherbert.com
+ */
+class Notifier {
+
+    /**
+     * The notifier instance.
+     *
+     * @var \Herbet\Framework\Notifier
+     */
+    protected static $instance;
+
+    /**
+     * The accumulated notices.
+     *
+     * @var array
+     */
+    protected $notices = [];
+
+    /**
+     * Constructs the Notifier.
+     */
+    public function __construct()
+    {
+        add_action('admin_notices', [$this, 'sendNotices']);
+    }
+
+    /**
+     * Adds a notice.
+     *
+     * @param        $message
+     * @param string $class
+     */
+    protected function notify($message, $class = 'updated')
+    {
+        $this->notices[] = [
+            'message' => $message,
+            'class'   => $class
+        ];
+    }
+
+    /**
+     * Adds a success notice.
+     *
+     * @param $message
+     */
+    protected function notifySuccess($message)
+    {
+        $this->notify($message, 'updated');
+    }
+
+    /**
+     * Adds a warning notice.
+     *
+     * @param $message
+     */
+    protected function notifyWarning($message)
+    {
+        $this->notify($message, 'update-nag');
+    }
+
+    /**
+     * Adds an error notice.
+     *
+     * @param $message
+     */
+    protected function notifyError($message)
+    {
+        $this->notify($message, 'error');
+    }
+
+    /**
+     * Sends all the accumulated notices.
+     *
+     * @return void
+     */
+    public function sendNotices()
+    {
+        foreach ($this->notices as $notice)
+        {
+            echo "<div class=\"{$notice['class']}\"><p>{$notice['message']}</p></div>";
+        }
+    }
+
+    /**
+     * Allow static calls — akin to a facade.
+     *
+     * @param  string $name
+     * @param  array  $arguments
+     * @return mixed
+     */
+    public static function __callStatic($name, $arguments)
+    {
+        if ( ! self::$instance)
+        {
+            self::$instance = new self;
+        }
+
+        return call_user_func_array([self::$instance, $name], $arguments);
+    }
+
+}

--- a/Herbert/Framework/Notifier.php
+++ b/Herbert/Framework/Notifier.php
@@ -46,7 +46,7 @@ class Notifier {
      *
      * @param $message
      */
-    protected function notifySuccess($message)
+    protected function success($message)
     {
         $this->notify($message, 'updated');
     }
@@ -56,7 +56,7 @@ class Notifier {
      *
      * @param $message
      */
-    protected function notifyWarning($message)
+    protected function warning($message)
     {
         $this->notify($message, 'update-nag');
     }
@@ -66,7 +66,7 @@ class Notifier {
      *
      * @param $message
      */
-    protected function notifyError($message)
+    protected function error($message)
     {
         $this->notify($message, 'error');
     }


### PR DESCRIPTION
You can now send notifications like: `Notifier::error('some message')`
