### PR TITLE
added the activation / deactivation calls w/ the variables scoped

### DIFF
--- a/Herbert/Framework/Application.php
+++ b/Herbert/Framework/Application.php
@@ -292,6 +292,20 @@ class Application extends \Illuminate\Container\Container implements \Illuminate
         {
             $plugin->activate();
         }
+
+        if ( ! file_exists($root . '/activate.php'))
+        {
+            return;
+        }
+
+        $this->loadWith("$root/activate.php", [
+            'http',
+            'router',
+            'enqueue',
+            'panel',
+            'shortcode',
+            'widget'
+        ]);
     }
 
     /**
@@ -311,6 +325,39 @@ class Application extends \Illuminate\Container\Container implements \Illuminate
         {
             $plugin->deactivate();
         }
+
+        if ( ! file_exists($root . '/deactivate.php'))
+        {
+            return;
+        }
+
+        $this->loadWith("$root/deactivate.php", [
+            'http',
+            'router',
+            'enqueue',
+            'panel',
+            'shortcode',
+            'widget'
+        ]);
+    }
+
+    /**
+     * Loads a file with variables in scope.
+     *
+     * @param  string $file
+     * @param  array  $refs
+     * @return void
+     */
+    protected function loadWith($file, $refs = [])
+    {
+        $container = $this;
+
+        foreach ($refs as $ref)
+        {
+            $$ref = $this[$ref];
+        }
+
+        @require $file;
     }
 
     /**


### PR DESCRIPTION
Adds the ability to use a `activate.php` and `deactivate.php` file for hooking into the activation/deactivation events for the plugin.

E.G (`activate.php` or `deactivate.php`):

``` php
<?php

// $container = Herbert\Framework\Application
// $http      = Herbert\Framework\Http
// $router    = Herbert\Framework\Router
// $enqueue   = Herbert\Framework\Enqueue
// $panel     = Herbert\Framework\Panel
// $shortcode = Herbert\Framework\Shortcode
// $widget    = Herbert\Framework\Widget
```

Activators and deactivators can be set via the `herbert.config.php` file, E.G:

``` php
<?php

return [

    /**
     * The plugin activators.
     */
    'activators' => [
        __DIR__ . '/activate.php'
    ],

    /**
     * The plugin deactivators.
     */
    'deactivators' => [
        __DIR__ . '/deactivate.php'
    ],

];
```
