### PR TITLE
Add Cache class for using WordPress built-in transients in more readable way

### DIFF
--- a/Herbert/Framework/cache.php
+++ b/Herbert/Framework/cache.php
@@ -1,0 +1,64 @@
+<?php namespace Herbert\Framework;
+
+/*
+ * This is wrapper for WordPress transient functions
+ * It uses anonymous functions so 
+ * 
+ * For Example turn this ugly code:
+ *
+    if (false === ( $events = get_transient( $transient ) ) ) {
+        $events = Event::all($start,$end);
+        set_transient( $transient, $result );
+    }
+    return $events;
+
+ * Into:
+ *
+    $events = Cache::store($transient,function() {
+        return Event::all($start,$end);
+    });
+    return $events;
+ */
+    
+class Cache {
+
+    /**
+     * Returns whatever is cached into $key.
+     * Runs $closure and stores it into $key when $closure returns non-empty response
+     *
+     * @param String $key - Key to store the result of the operation
+     *
+     * @param Closure $closure - Anonymous function which is run only when needed
+     *
+     * @return mixed - Returns the result of $closure from cache
+     */
+    public static function store($key,$closure) {
+        if ( self::bypassCache() || false === ( $result = get_transient( $key ) ) ) {
+          $result = $closure();
+          if (!empty($result)) {
+            set_transient( $key, $result );
+          }
+        }
+        return $result;
+    }
+
+    /**
+     * Delete something from the cache
+     *
+     * @param String $key - Key to delete the from cache
+     *
+     * @return mixed - Returns the result of $closure from cache
+     */
+    public static function delete($key) {
+        return delete_transient($key);
+    }
+
+    /**
+     * Check if the request has PRAGMA header set to no-cache
+     *
+     * @return Boolean
+     */
+    public static function bypassCache() {
+         return (isset($_SERVER['HTTP_PRAGMA']) && $_SERVER['HTTP_PRAGMA'] === 'no-cache');
+    }
+}

--- a/Herbert/Framework/cache.php
+++ b/Herbert/Framework/cache.php
@@ -1,23 +1,22 @@
 <?php namespace Herbert\Framework;
 
+use Closure;
 /*
  * This is wrapper for WordPress transient functions
  * It uses anonymous functions so 
  * 
  * For Example turn this ugly code:
  *
-    if (false === ( $events = get_transient( $transient ) ) ) {
+    if (false === ( $events = get_transient( 'my-events' ) ) ) {
         $events = Event::all($start,$end);
-        set_transient( $transient, $result );
+        set_transient( 'my-events', $result );
     }
-    return $events;
 
  * Into:
  *
-    $events = Cache::store($transient,function() {
+    $events = Cache::store('my-events',function() {
         return Event::all($start,$end);
     });
-    return $events;
  */
     
 class Cache {
@@ -32,7 +31,8 @@ class Cache {
      *
      * @return mixed - Returns the result of $closure from cache
      */
-    public static function store($key,$closure) {
+    public static function store($key,Closure $closure)
+    {
         if ( self::bypassCache() || false === ( $result = get_transient( $key ) ) ) {
           $result = $closure();
           if (!empty($result)) {
@@ -49,16 +49,18 @@ class Cache {
      *
      * @return mixed - Returns the result of $closure from cache
      */
-    public static function delete($key) {
+    public static function delete($key)
+    {
         return delete_transient($key);
     }
 
     /**
      * Check if the request has PRAGMA header set to no-cache
      *
-     * @return Boolean
+     * @return bool
      */
-    public static function bypassCache() {
+    public static function bypassCache()
+    {
          return (isset($_SERVER['HTTP_PRAGMA']) && $_SERVER['HTTP_PRAGMA'] === 'no-cache');
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -3,6 +3,7 @@
   "description": "Herbert",
   "license": "MIT",
   "require": {
+    "php": ">=5.4.0",
     "twig/twig": "~1.16",
     "illuminate/database": "~5.0",
     "vierbergenlars/php-semver": "~3.0",


### PR DESCRIPTION
Hello!

I just love to use transients for almost everything in WordPress. It enhances loading speeds significantly. But I'm always frustrated how ugly it looks:

``` php
if (false === ( $resources = get_transient( 'my-resources' ) ) ) {
    $resources = Resource::all($start,$end);
    set_transient( 'my-resources', $resources );
}
```

I used anonymous functions to create `Cache` class so you could refactor upper code example into:

``` php
$resources = Cache::store('my-resources',function() {
    return Resource::all($start,$end);
});
```

This should be familiar for all javascript guys using herbert.
This also respects `Pragma: no-cache` headers from the request.

There might be better and more readable ways than this but I'm adding it here as a suggestion.
