### PR TITLE
Fix: open_basedir restriction

### DIFF
--- a/Herbert/Framework/Providers/TwigServiceProvider.php
+++ b/Herbert/Framework/Providers/TwigServiceProvider.php
@@ -20,7 +20,7 @@ class TwigServiceProvider extends ServiceProvider {
     {
         $this->app->singleton('twig.loader', function ()
         {
-            $loader = new Twig_Loader_Filesystem('/');
+            $loader = new Twig_Loader_Filesystem();
 
             foreach ($this->app->getPlugins() as $plugin)
             {


### PR DESCRIPTION
Plugin activation results on some setups in following error:
Warning: is_dir(): open_basedir restriction in effect. File(/) is not within the allowed path(s): (/xxx/:/tmp) in /xxx/vendor/twig/twig/lib/Twig/Loader/Filesystem.php on line 93
This can be easily fixed applying this simple change.
