### PR TITLE
To Set COLLATE as Wordpress Default Collate

### DIFF
--- a/Herbert/Framework/Providers/HerbertServiceProvider.php
+++ b/Herbert/Framework/Providers/HerbertServiceProvider.php
@@ -135,7 +135,7 @@ class HerbertServiceProvider extends ServiceProvider {
             'username' => DB_USER,
             'password' => DB_PASSWORD,
             'charset' => DB_CHARSET,
-            'collation' => DB_COLLATE ?: 'utf8_general_ci',
+            'collation' => DB_COLLATE ?: $wpdb->collate,
             'prefix' => $wpdb->prefix
         ]);
 


### PR DESCRIPTION
TO Set Default Collate to Avoid PDO Exceptions
