### PR TITLE
Router argument issue

### DIFF
--- a/Herbert/Framework/Router.php
+++ b/Herbert/Framework/Router.php
@@ -94,11 +94,15 @@ class Router {
     public function boot()
     {
         add_rewrite_tag('%herbert_route%', '(.+)');
-
-        foreach ($this->routes[$this->http->method()] as $id => $route)
+        
+        if(is_array($this->routes[$this->http->method()]))
         {
-            $this->addRoute($route, $id, $this->http->method());
+            foreach ($this->routes[$this->http->method()] as $id => $route)
+            {
+                $this->addRoute($route, $id, $this->http->method());
+            } 
         }
+        
     }
 
     /**


### PR DESCRIPTION
I don't generate any routes with herbert.  I noticed that my nginx error log was getting flooded with errors about foreach not having a valid argument in this method. So I added a check for an array before trying to iterate it. No more log spam.
