### PR TITLE
incorrect shortcode callback invocation

### DIFF
--- a/Herbert/Framework/Shortcode.php
+++ b/Herbert/Framework/Shortcode.php
@@ -62,10 +62,7 @@ class Shortcode {
 
             $response = $this->app->call(
                 $callable,
-                array_merge([
-                    '_attributes' => $attributes,
-                    '_content'    => $content
-                ], $attributes)
+                $attributes
             );
 
             if ($response instanceof RedirectResponse)


### PR DESCRIPTION
Unless I'm missing something, there also seems to be a bug in the way the shortcode callback is being invoked, since all the parameters are being merged into an array. Commit c5ae587 addresses that.
