### PR TITLE
CHARSET issue with Native Wordpress CHARSET

### DIFF
--- a/Herbert/Framework/Providers/HerbertServiceProvider.php
+++ b/Herbert/Framework/Providers/HerbertServiceProvider.php
@@ -134,8 +134,8 @@ class HerbertServiceProvider extends ServiceProvider {
             'database' => DB_NAME,
             'username' => DB_USER,
             'password' => DB_PASSWORD,
-            'charset' => DB_CHARSET,
-            'collation' => DB_COLLATE ?: $wpdb->collate,
+            'charset' => $wpdb->charset,
+            'collation' => $wpdb->collate,
             'prefix' => $wpdb->prefix
         ]);
 


### PR DESCRIPTION
In Wordpress manual setup of "Charset" and "Collation" is not properly verified by the user.
So, 
   Charset and Collation is not matched.
