### PR TITLE
Fixes: PHP Fatal error on PHP 7.3.2

### DIFF
--- a/Herbert/Framework/Notifier.php
+++ b/Herbert/Framework/Notifier.php
@@ -1,4 +1,5 @@
-<?php namespace Herbert\Framework;
+<?php 
+namespace Herbert\Framework;
 
 /**
  * @see http://getherbert.com


### PR DESCRIPTION
`PHP Fatal error:  Uncaught RuntimeException: Failed to start the session because headers have already been sent by "" at line 0` caused by namespace being on the same line as the opening `<?php` tag.